### PR TITLE
Adds a Deep Dip Extension

### DIFF
--- a/src/Main.as
+++ b/src/Main.as
@@ -7,6 +7,9 @@ bool Setting_OnlyInSpec = false;
 [Setting name="Minimize When Not Hovering" category=" Window" description="Minimize the window when the mouse is not hovering the window."]
 bool Setting_MinimizeWhenNotHovering = false;
 
+[Setting name="Enable Deep Dip" category=" Window" description="Enable the Deep Dip extension, when in a Deep Dip 2 server."]
+bool Setting_EnableDeepDip = false;
+
 [Setting name="Lock Position" category=" Window" description="Disable the ability to move the window and lock it in place."]
 bool Setting_LockPosition = false;
 

--- a/src/Utils.as
+++ b/src/Utils.as
@@ -46,3 +46,88 @@ bool IsTeamsMode() {
 bool IsKnockoutDaily() {
     return GetApp().Network.ClientManiaAppPlayground.ManiaPlanet.CurrentServerModeName == "TM_KnockoutDaily_Online";
 }
+
+string LoginToWSID(const string &in login) {
+    auto buf = MemoryBuffer();
+    buf.WriteFromBase64(login, true);
+    auto hex = BufferToHex(buf);
+    return hex.SubStr(0, 8)
+        + "-" + hex.SubStr(8, 4)
+        + "-" + hex.SubStr(12, 4)
+        + "-" + hex.SubStr(16, 4)
+        + "-" + hex.SubStr(20)
+        ;
+}
+
+string BufferToHex(MemoryBuffer@ buf) {
+    buf.Seek(0);
+    auto size = buf.GetSize();
+    string ret;
+    for (uint i = 0; i < size; i++) {
+        ret += Uint8ToHex(buf.ReadUInt8());
+    }
+    return ret;
+}
+
+string Uint8ToHex(uint8 val) {
+    return Uint4ToHex(val >> 4) + Uint4ToHex(val & 0xF);
+}
+
+string Uint4ToHex(uint8 val) {
+    if (val > 0xF) throw('val out of range: ' + val);
+    string ret = " ";
+    if (val < 10) {
+        ret[0] = val + 0x30;
+    } else {
+        // 0x61 = a
+        ret[0] = val - 10 + 0x61;
+    }
+    return ret;
+}
+
+//Adds headers to an HTTP request
+string SendJSONRequest(const Net::HttpMethod Method, const string &in URL, string Body = "") {
+    dictionary@ Headers = dictionary();
+    Headers["Accept"] = "application/json";
+    Headers["Content-Type"] = "application/json";
+    Headers["User-Agent"] = "Too many players extension for Deep Dip. Made by @JohanClan on discord";
+    return SendHTTPRequest(Method, URL, Body, Headers);
+}
+
+//Bundles everything together for an HTTP Request
+string SendHTTPRequest(const Net::HttpMethod Method, const string &in URL, const string &in Body, dictionary@ Headers) {
+    Net::HttpRequest req;
+    req.Method = Method;
+    req.Url = URL;
+    @req.Headers = Headers;
+    req.Body = Body;
+    req.Start();
+    while (!req.Finished()) {
+        yield();
+    }
+
+    return req.String();
+}
+
+//Handles the response
+Json::Value ResponseToJSON(const string &in HTTPResponse, Json::Type ExpectedType) {
+    Json::Value ReturnedObject;
+    try {
+        ReturnedObject = Json::Parse(HTTPResponse);
+    } catch {
+        print("JSON Parsing of string failed!");
+    }
+    if (ReturnedObject.GetType() != ExpectedType) {
+        print("Unexpected JSON Type returned");
+        return ReturnedObject;
+    }
+    return ReturnedObject;
+}
+
+bool shouldShowDeepDipInfo() {
+    return Setting_EnableDeepDip && getMapUid() == 'DeepDip2__The_Storm_Is_Here';
+}
+
+string getMapUid(){
+    return GetApp().RootMap.MapInfo.MapUid;
+}

--- a/src/WidgetWindow.as
+++ b/src/WidgetWindow.as
@@ -98,6 +98,11 @@ class WidgetWindow {
         }
 
         UI::End();
+
+        if(shouldShowDeepDipInfo()) {
+            RenderDeepDipInfo();
+        }
+
     }
 
     void RenderSearch() {
@@ -302,6 +307,17 @@ class WidgetWindow {
             UI::Text(text);
             UI::EndTooltip();
         }
+    }
+
+    void RenderDeepDipInfo() {
+        UI::SetNextWindowContentSize(330, 120);
+        UI::Begin("Deep Dip info");
+        UI::NewLine();
+        UI::Text("Height PB:  " + _playerList.GetCurrentPb());
+        UI::NewLine();
+        UI::Text("Rank:  " + _playerList.GetCurrentRank());
+
+        UI::End();
     }
 }
 

--- a/src/info.toml
+++ b/src/info.toml
@@ -2,7 +2,4 @@
 name        = "Too Many Players"
 author      = "snixtho"
 category    = "Utilities"
-version     = "2.2"
-
-[script]
-imports = [ "Icons.as" ]
+version     = "2.3"


### PR DESCRIPTION
Adds an option to enable a Deep Dip extension that show the Height PB and rank of the currently spectated player.

When the setting is enabled, the deep dip info still only shows up if on a server with Deep Dip 2.
![image](https://github.com/snixtho/tm-too-many-players/assets/56736335/6186c7e8-b062-4566-880a-85f719cc1ca1)
![image](https://github.com/snixtho/tm-too-many-players/assets/56736335/88c01a72-37b9-4011-8ca3-e2564b8bc78f)
